### PR TITLE
Fix JobIntentService Permission Error

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="kirimin.me.emojires">
 
+    <uses-permission android:name="android.permission.WAKE_LOCK"/>
+
     <application
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Hi,kirimin-chan

I am always looking forward to youtube live:heart:

but, emoji_res can't launch the app in my device.
JobIntentService need WAKE_LOCK permission when pre Oreo.

see https://developer.android.com/reference/android/support/v4/app/JobIntentService

Thank you for looking!